### PR TITLE
ci: add binary release ci task

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,4 @@ jobs:
         goarch: ${{ matrix.goarch }}
         goversion: "1.19"
         build_command: "make"
+        executable_compression: "upx"


### PR DESCRIPTION
This patch adds a task to create executable binaries for various platforms.