### PR TITLE
ci: add license header checker and update README

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Greptime Team
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: CI
 
 on: [push, pull_request]

--- a/.github/workflows/license-checker.yaml
+++ b/.github/workflows/license-checker.yaml
@@ -1,0 +1,16 @@
+name: License checker
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+jobs:
+  license-header-check:
+    runs-on: ubuntu-latest
+    name: license-header-check
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check License Header
+        uses: apache/skywalking-eyes/header@main

--- a/.github/workflows/pr-title-checker.yaml
+++ b/.github/workflows/pr-title-checker.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Greptime Team
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: PR Title Checker
 
 on: [pull_request]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,3 @@
-# Copyright 2022 Greptime Team
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: Release
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Greptime Team
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 header:
   license:
     spdx-id: Apache-2.0
@@ -21,10 +7,9 @@ header:
     - "**/*.go"
     - "**/*.sh"
     - "Makefile"
-    - "**/*.yaml"
 
   comment: on-failure
 
 dependency:
   files:
-    - Cargo.toml
+    - go.mod

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,7 @@ setup-e2e: ## Setup e2e test environment.
 .PHONY: e2e
 e2e: gtctl setup-e2e ## Run e2e
 	go test -timeout 8m -v ./tests/e2e/... && kind delete clusters ${CLUSTER}
+
+.PHONY: fix-license-header
+fix-license-header: ## Fix license header
+	license-eye -c .licenserc.yaml header fix

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 CLUSTER=e2e-cluster
+LDFLAGS = $(shell ./hack/version.sh)
 
 .PHONY: gtctl
-LDFLAGS = $(shell ./hack/version.sh)
-gtctl:
+gtctl: ## Build gtctl.
 	@go build -ldflags '${LDFLAGS}' -o bin/gtctl ./cmd/gtctl
 
 .PHONY: setup-e2e
@@ -24,9 +24,30 @@ setup-e2e: ## Setup e2e test environment.
 	./hack/e2e/setup-e2e-env.sh
 
 .PHONY: e2e
-e2e: gtctl setup-e2e ## Run e2e
+e2e: gtctl setup-e2e ## Run e2e.
 	go test -timeout 8m -v ./tests/e2e/... && kind delete clusters ${CLUSTER}
 
 .PHONY: fix-license-header
-fix-license-header: ## Fix license header
+fix-license-header: license-eye ## Fix license header.
 	license-eye -c .licenserc.yaml header fix
+
+.PHONY: license-eye
+license-eye: ## Install license-eye.
+	@which license-eye || go install github.com/apache/skywalking-eyes/cmd/license-eye@latest
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# https://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display help messages.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2022 Greptime Team
+# Copyright 2023 Greptime Team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`gtctl`(`g-t-control`) is a command-line tool for managing the [GreptimeDB](https://github.com/GrepTimeTeam/greptimedb) cluster. gtctl is the **All-in-One** binary that integrates multiple operations of the GreptimeDB cluster.
+`gtctl`(`g-t-control`) is a command-line tool for managing the [GreptimeDB](https://github.com/GrepTimeTeam/greptimedb) cluster. `gtctl` is the **All-in-One** binary that integrates multiple operations of the GreptimeDB cluster.
 
 <p align="center">
 <img alt="screenshot" src="./docs/images/screenshot.png" width="800px">

--- a/cmd/gtctl/main.go
+++ b/cmd/gtctl/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hack/e2e/setup-e2e-env.sh
+++ b/hack/e2e/setup-e2e-env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Greptime Team
+# Copyright 2023 Greptime Team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2022 Greptime Team
+# Copyright 2023 Greptime Team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Greptime Team
+# Copyright 2023 Greptime Team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/cmd/gtctl/cluster/cluster.go
+++ b/pkg/cmd/gtctl/cluster/cluster.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/gtctl/cluster/create/create.go
+++ b/pkg/cmd/gtctl/cluster/create/create.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/gtctl/cluster/delete/delete.go
+++ b/pkg/cmd/gtctl/cluster/delete/delete.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/gtctl/cluster/get/get.go
+++ b/pkg/cmd/gtctl/cluster/get/get.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/gtctl/cluster/list/list.go
+++ b/pkg/cmd/gtctl/cluster/list/list.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/gtctl/cluster/scale/scale.go
+++ b/pkg/cmd/gtctl/cluster/scale/scale.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/gtctl/root.go
+++ b/pkg/cmd/gtctl/root.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/gtctl/version/version.go
+++ b/pkg/cmd/gtctl/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/deployer/k8s/constants.go
+++ b/pkg/deployer/k8s/constants.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/deployer/k8s/deployer.go
+++ b/pkg/deployer/k8s/deployer.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/deployer/types.go
+++ b/pkg/deployer/types.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/e2e/greptimedbcluster_test.go
+++ b/tests/e2e/greptimedbcluster_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Add license checker CI job;
- Update copyright year;
- Remove unnecessary license header from some files;
- Update `.licenserc.yaml` and add the `make fix-license-header` command;