### PR TITLE
refactor: support golangci-lint  

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,15 @@
 name: CI
 
-on: [push, pull_request]
+on: [
+  push,
+  pull_request
+]
+
+env:
+  GO_VERSION: "1.21"
+
+permissions:
+  contents: read
 
 jobs:
   typos-check:
@@ -11,8 +20,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Check spelling with custom config file
         uses: crate-ci/typos@v1.14.8
-  linter:
-    name: linter
+
+  lint:
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -21,17 +31,19 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18.4"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.3.0
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.0
-          args: --timeout 10m0s
+          version: v1.54
+          # '-v' flag is required to show the output of golangci-lint.
+          args: -v
+
   unit-test:
     name: coverage-test
     runs-on: ubuntu-latest
-    needs: [ linter ]
+    needs: [ lint ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -39,11 +51,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18.4"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Unit test
         run: |
           make coverage
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
@@ -52,10 +65,10 @@ jobs:
           files: ./coverage.xml
           name: codecov-gtctl
           verbose: true
-  e2e-test:
-    name: e2e-test
+  e2e:
+    name: e2e
     runs-on: ubuntu-latest
-    needs: [ linter ]
+    needs: [ lint ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -63,8 +76,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18.4"
+          go-version: ${{ env.GO_VERSION }}
 
-      - name: e2e test of basic cluster
+      - name: Run e2e
         run: |
           make e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,12 @@
 name: Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "v*"
+
+env:
+  GO_VERSION: "1.21"
 
 jobs:
   build:
@@ -35,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18.4"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Build project
         run: |
@@ -76,8 +80,13 @@ jobs:
         uses: actions/download-artifact@v3
 
       - name: Publish release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
           name: "Release ${{ github.ref_name }}"
-          files: |
+          prerelease: false
+          make_release: true
+          generateReleaseNotes: true
+          allowUpdates: true
+          tag: ${{ github.ref_name }}
+          artifacts: |
             **/gtctl-*

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,95 @@
+# Options for analysis running.
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 10m
+
+  # The default concurrency value is the number of available CPU.
+  concurrency: 4
+
+  # Which dirs to skip: issues from them won't be reported.
+  # Can use regexp here: `generated.*`, regexp is applied on full path,
+  # including the path prefix if one is set.
+  # Default value is empty list,
+  # but default dirs are skipped independently of this option's value (see skip-dirs-use-default).
+  # "/" will be replaced by current OS file path separator to properly work on Windows.
+  skip-dirs:
+    - bin
+    - docs
+    - examples
+    - hack
+
+# output configuration options.
+output:
+  # Format: colored-line-number|line-number|json|colored-tab|tab|checkstyle|code-climate|junit-xml|github-actions|teamcity
+  #
+  # Multiple can be specified by separating them by comma, output can be provided
+  # for each of them by separating format name and path by colon symbol.
+  # Output path can be either `stdout`, `stderr` or path to the file to write to.
+  # Example: "checkstyle:report.xml,json:stdout,colored-line-number"
+  #
+  # Default: colored-line-number
+  format: colored-line-number
+
+  # Print lines of code with issue.
+  # Default: true
+  print-issued-lines: true
+
+  # Print linter name in the end of issue text.
+  # Default: true
+  print-linter-lines: true
+
+linters:
+  # Disable all linters.
+  disable-all: true
+
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    # Errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases.
+    - errcheck
+
+    # Linter for Go source code that specializes in simplifying code.
+    - gosimple
+
+    # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string.
+    - govet
+
+    # Detects when assignments to existing variables are not used.
+    - ineffassign
+
+    # It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary.
+    # The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
+    - staticcheck
+
+    # Check import statements are formatted according to the 'goimport' command. Reformat imports in autofix mode.
+    - goimports
+
+    # Checks whether HTTP response body is closed successfully.
+    - bodyclose
+
+    # Provides diagnostics that check for bugs, performance and style issues.
+    # Extensible without recompilation through dynamic rules.
+    # Dynamic rules are written declaratively with AST patterns, filters, report message and optional suggestion.
+    - gocritic
+
+    # Gofmt checks whether code was gofmt-ed. By default, this tool runs with -s option to check for code simplification.
+    - gofmt
+
+    # Finds repeated strings that could be replaced by a constant.
+    - goconst
+
+    # Finds commonly misspelled English words in comments.
+    - misspell
+
+    # Finds naked returns in functions greater than a specified function length.
+    - nakedret
+
+linters-settings:
+  goimports:
+    # A comma-separated list of prefixes, which, if set, checks import paths
+    # with the given prefixes are grouped after 3rd-party packages.
+    # Default: ""
+    local-prefixes: github.com/GreptimeTeam/gtctl
+  linters-settings:
+    min-occurrences: 3

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,13 @@
 CLUSTER=e2e-cluster
 LDFLAGS = $(shell ./hack/version.sh)
 
+##@ Build
+
 .PHONY: gtctl
 gtctl: ## Build gtctl.
 	@go build -ldflags '${LDFLAGS}' -o bin/gtctl ./cmd/gtctl
+
+##@ Development
 
 .PHONY: setup-e2e
 setup-e2e: ## Setup e2e test environment.
@@ -26,6 +30,10 @@ setup-e2e: ## Setup e2e test environment.
 .PHONY: e2e
 e2e: gtctl setup-e2e ## Run e2e.
 	go test -timeout 8m -v ./tests/e2e/... && kind delete clusters ${CLUSTER}
+
+.PHONY: lint
+lint: golangci-lint gtctl ## Run lint.
+	golangci-lint run -v ./...
 
 .PHONY: test
 test: ## Run unit test.
@@ -39,9 +47,15 @@ coverage: ## Run unit test with coverage.
 fix-license-header: license-eye ## Fix license header.
 	license-eye -c .licenserc.yaml header fix
 
+##@ Tools Installation
+
 .PHONY: license-eye
 license-eye: ## Install license-eye.
 	@which license-eye || go install github.com/apache/skywalking-eyes/cmd/license-eye@latest
+
+.PHONY: golangci-lint
+golangci-lint: ## Install golangci-lint.
+	@which golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.1
 
 ##@ General
 

--- a/pkg/cmd/gtctl/cluster/connect/connect.go
+++ b/pkg/cmd/gtctl/cluster/connect/connect.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"fmt"
 
+	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/GreptimeTeam/gtctl/pkg/cmd/gtctl/cluster/connect/mysql"
 	"github.com/GreptimeTeam/gtctl/pkg/cmd/gtctl/cluster/connect/pg"
 	"github.com/GreptimeTeam/gtctl/pkg/deployer/k8s"

--- a/pkg/cmd/gtctl/cluster/connect/mysql/mysql.go
+++ b/pkg/cmd/gtctl/cluster/connect/mysql/mysql.go
@@ -23,9 +23,9 @@ import (
 	"sync"
 	"syscall"
 
+	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/go-sql-driver/mysql"
 
-	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/GreptimeTeam/gtctl/pkg/logger"
 )
 
@@ -58,7 +58,7 @@ func connect(port, clusterName string, l logger.Logger) error {
 	go func() {
 		defer waitGroup.Done()
 		if err = cmd.Wait(); err != nil {
-			//exit status 1
+			// exit status 1
 			exitError, ok := err.(*exec.ExitError)
 			if !ok {
 				l.Errorf("Error waiting for port-forwarding to finish: %v", err)

--- a/pkg/cmd/gtctl/cluster/connect/pg/pg.go
+++ b/pkg/cmd/gtctl/cluster/connect/pg/pg.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"syscall"
 
+	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/go-pg/pg/v10"
 
-	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/GreptimeTeam/gtctl/pkg/logger"
 )
 
@@ -65,7 +65,7 @@ func connect(port, clusterName string, l logger.Logger) error {
 	go func() {
 		defer waitGroup.Done()
 		if err = cmd.Wait(); err != nil {
-			//exit status 1
+			// exit status 1
 			exitError, ok := err.(*exec.ExitError)
 			if !ok {
 				l.Errorf("Error waiting for port-forwarding to finish: %v", err)

--- a/pkg/cmd/gtctl/cluster/delete/delete.go
+++ b/pkg/cmd/gtctl/cluster/delete/delete.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"strings"
 
+	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/GreptimeTeam/gtctl/pkg/cmd/gtctl/cluster/common"
 	"github.com/GreptimeTeam/gtctl/pkg/deployer/k8s"
 	"github.com/GreptimeTeam/gtctl/pkg/logger"

--- a/pkg/cmd/gtctl/cluster/get/get.go
+++ b/pkg/cmd/gtctl/cluster/get/get.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"fmt"
 
+	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/GreptimeTeam/gtctl/pkg/deployer/k8s"
 	"github.com/GreptimeTeam/gtctl/pkg/logger"
 )

--- a/pkg/cmd/gtctl/cluster/list/list.go
+++ b/pkg/cmd/gtctl/cluster/list/list.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 
+	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/GreptimeTeam/gtctl/pkg/deployer/k8s"
 	"github.com/GreptimeTeam/gtctl/pkg/logger"
 )

--- a/pkg/cmd/gtctl/cluster/scale/scale.go
+++ b/pkg/cmd/gtctl/cluster/scale/scale.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"fmt"
 
+	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/GreptimeTeam/gtctl/pkg/deployer"
 	"github.com/GreptimeTeam/gtctl/pkg/deployer/k8s"
 	"github.com/GreptimeTeam/gtctl/pkg/logger"

--- a/pkg/cmd/gtctl/constants/constants.go
+++ b/pkg/cmd/gtctl/constants/constants.go
@@ -14,11 +14,11 @@
 
 package constants
 
-// GtctlTextBanner is the following text banner for gtctl.
-//           __       __  __
-//    ____ _/ /______/ /_/ /
-//   / __ `/ __/ ___/ __/ /
-//  / /_/ / /_/ /__/ /_/ /
-//  \__, /\__/\___/\__/_/
-// /____/
-const GtctlTextBanner = "          __       __  __\n   ____ _/ /______/ /_/ /\n  / __ `/ __/ ___/ __/ / \n / /_/ / /_/ /__/ /_/ /  \n \\__, /\\__/\\___/\\__/_/   \n/____/   \n"
+// GtctlTextBanner represents the ASCII art banner for the gtctl command-line tool.
+const GtctlTextBanner = `
+          __       __  __
+   ____ _/ /______/ /_/ /
+  / __ '/ __/ ___/ __/ / 
+ / /_/ / /_/ /__/ /_/ /  
+ \__, /\__/\___/\__/_/   
+/____/`

--- a/pkg/deployer/baremetal/artifacts.go
+++ b/pkg/deployer/baremetal/artifacts.go
@@ -25,11 +25,12 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/google/go-github/v53/github"
+
 	"github.com/GreptimeTeam/gtctl/pkg/deployer/baremetal/config"
 	"github.com/GreptimeTeam/gtctl/pkg/logger"
 	fileutils "github.com/GreptimeTeam/gtctl/pkg/utils/file"
 	semverutils "github.com/GreptimeTeam/gtctl/pkg/utils/semver"
-	"github.com/google/go-github/v53/github"
 )
 
 const (

--- a/pkg/deployer/baremetal/component/datanode.go
+++ b/pkg/deployer/baremetal/component/datanode.go
@@ -118,7 +118,7 @@ CHECKER:
 func (d *datanode) BuildArgs(ctx context.Context, params ...interface{}) []string {
 	logLevel := d.config.LogLevel
 	if logLevel == "" {
-		logLevel = "info"
+		logLevel = config.DefaultLogLevel
 	}
 
 	nodeID_, walDir, dataHomeDir := params[0], params[1], params[2]

--- a/pkg/deployer/baremetal/component/frontend.go
+++ b/pkg/deployer/baremetal/component/frontend.go
@@ -85,7 +85,7 @@ func (f *frontend) Start(ctx context.Context, binary string) error {
 func (f *frontend) BuildArgs(ctx context.Context, params ...interface{}) []string {
 	logLevel := f.config.LogLevel
 	if logLevel == "" {
-		logLevel = "info"
+		logLevel = config.DefaultLogLevel
 	}
 	args := []string{
 		fmt.Sprintf("--log-level=%s", logLevel),

--- a/pkg/deployer/baremetal/component/metasrv.go
+++ b/pkg/deployer/baremetal/component/metasrv.go
@@ -99,7 +99,7 @@ CHECKER:
 func (m *metaSrv) BuildArgs(ctx context.Context, params ...interface{}) []string {
 	logLevel := m.config.LogLevel
 	if logLevel == "" {
-		logLevel = "info"
+		logLevel = config.DefaultLogLevel
 	}
 	args := []string{
 		fmt.Sprintf("--log-level=%s", logLevel),

--- a/pkg/deployer/baremetal/config/common.go
+++ b/pkg/deployer/baremetal/config/common.go
@@ -20,6 +20,8 @@ const (
 
 	DefaultEtcdVersion     = "v3.5.7"
 	DefaultGreptimeVersion = "latest"
+
+	DefaultLogLevel = "info"
 )
 
 // Config is the desired state of a GreptimeDB cluster on bare metal.

--- a/pkg/deployer/k8s/deployer.go
+++ b/pkg/deployer/k8s/deployer.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
+
 	. "github.com/GreptimeTeam/gtctl/pkg/deployer"
 	"github.com/GreptimeTeam/gtctl/pkg/helm"
 	"github.com/GreptimeTeam/gtctl/pkg/kube"


### PR DESCRIPTION
## What's changed

1. Add `.golangci.yaml` and `make lint`;
2. Fix lint errors that are found by `make lint`;
3. Refine GitHub Actions(multiple minor changes):
   
   - Use the latest Go version;
   - Refine naming: `linter` -> `lint`;
   - Use `ncipollo/release-action@v1` as release workflow;
   - Update `golangci-lint` version;
   - Release `gtctl` by only creating a version tag and use `ncipollo/release-action` to release artifacts'(same as greptimedb actions);


## Related issues

- https://github.com/GreptimeTeam/gtctl/issues/121
- https://github.com/GreptimeTeam/gtctl/issues/83