### PR TITLE
chore: refactor the 'install.sh' and release to aws-cn s3 bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,23 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      release-install-script:
+        type: boolean
+        description: "Release install script to AWS-CN S3 bucket"
+        required: false
+        default: true
 
 env:
   GO_VERSION: "1.21"
+  MAX_UPLOAD_RETRY_TIMES: 20
+  UPLOAD_RETRY_TIMEOUT: 10 # minutes
 
 jobs:
   build:
     name: build-binary
+    if: ${{ github.event_name == 'push' }}
     strategy:
       matrix:
         # The file format is gtctl-<os>-<arch>
@@ -75,8 +85,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_CN_SECRET_ACCESS_KEY}}
           AWS_DEFAULT_REGION: ${{ vars.AWS_CN_RELEASE_BUCKET_REGION }}
         with:
-          max_attempts: 20
-          timeout_minutes: 5
+          max_attempts: ${{ env.MAX_UPLOAD_RETRY_TIMES }}
+          timeout_minutes: ${{ env.UPLOAD_RETRY_TIMEOUT }}
           command: |
             aws s3 cp \
               bin/${{ matrix.file }}.tgz \
@@ -113,3 +123,23 @@ jobs:
           tag: ${{ github.ref_name }}
           artifacts: |
             **/gtctl-*
+
+  release-install-script:
+    name: release-install-script
+    if: ${{ inputs.release-install-script }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Upload install.sh to S3
+        uses: nick-invision/retry@v2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_CN_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_CN_SECRET_ACCESS_KEY}}
+          AWS_DEFAULT_REGION: ${{ vars.AWS_CN_RELEASE_BUCKET_REGION }}
+        with:
+          max_attempts: ${{ env.MAX_UPLOAD_RETRY_TIMES }}
+          timeout_minutes: ${{ env.UPLOAD_RETRY_TIMEOUT }}
+          command: |
+            aws s3 cp hack/install.sh s3://${{ vars.AWS_CN_RELEASE_BUCKET }}/releases/scripts/gtctl/install.sh

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -13,65 +13,117 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -ue
 
 OS_TYPE=
 ARCH_TYPE=
-VERSION=${1:-latest}
-GITHUB_ORG=${2:-GreptimeTeam}
-GITHUB_REPO=gtctl
-BIN=gtctl
+VERSION="latest"
+GITHUB_ORG="GreptimeTeam"
+GITHUB_REPO="gtctl"
+BIN="gtctl"
+DOWNLOAD_SOURCE="github"
+INSTALL_DIR=$(PWD)
+GREPTIME_AWS_CN_RELEASE_BUCKET="https://downloads.greptime.cn/releases"
+
+usage() {
+    echo "Usage: $0 [-s <source>] [-v <version>] [-o <organization>] [-i]"
+    echo "Options:"
+    echo "  -s  Download source. Options: github, aws. Default: github."
+    echo "  -v  Version of the binary to install. Default: latest."
+    echo "  -o  Organization of the repository. Default: GreptimeTeam."
+    echo "  -r  Repository name. Default: gtctl."
+    echo "  -i  Install to /usr/local/bin."
+}
+
+download_from_github() {
+    if [ "${VERSION}" = "latest" ]; then
+        wget "https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest/download/${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz"
+        wget "https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest/download/${BIN}-${OS_TYPE}-${ARCH_TYPE}.sha256sum"
+    else
+        wget "https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${VERSION}/${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz"
+        wget "https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${VERSION}/${BIN}-${OS_TYPE}-${ARCH_TYPE}.sha256sum"
+    fi
+}
+
+download_from_aws() {
+    wget "$GREPTIME_AWS_CN_RELEASE_BUCKET/${GITHUB_REPO}/${VERSION}/${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz"
+    wget "$GREPTIME_AWS_CN_RELEASE_BUCKET/${GITHUB_REPO}/${VERSION}/${BIN}-${OS_TYPE}-${ARCH_TYPE}.sha256sum"
+}
+
+verify_sha256sum() {
+    command -v shasum >/dev/null 2>&1 || { echo "WARN: shasum command not found, skip sha256sum verification."; return; }
+
+    ARTIFACT_FILE="$1"
+    SUM_FILE="$2"
+
+    # Calculate sha256sum of the downloaded file.
+    CALCULATE_SUM=$(shasum -a 256 "$ARTIFACT_FILE" | cut -f1 -d' ')
+
+    if [ "${CALCULATE_SUM}" != "$(cat "$SUM_FILE")" ]; then
+        echo "ERROR: sha256sum verification failed for $ARTIFACT_FILE"
+        exit 1
+    else
+        echo "sha256sum verification succeeded for $ARTIFACT_FILE, checksum: $CALCULATE_SUM"
+    fi
+}
+
+install_binary() {
+    tar xvf "${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz"
+    if [ "${INSTALL_DIR}" = "/usr/local/bin/" ]; then
+        sudo mv "${BIN}" "${INSTALL_DIR}"
+        echo "Run '${BIN} --help' to get started"
+    else
+        echo "Run './${BIN} --help' to get started"
+    fi
+
+    # Clean the download package.
+    rm "${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz"
+    rm "${BIN}-${OS_TYPE}-${ARCH_TYPE}.sha256sum"
+}
 
 get_os_type() {
-    os_type="$(uname -s)"
-
-    case "$os_type" in
-    Darwin)
-        OS_TYPE=darwin
-        ;;
-    Linux)
-        OS_TYPE=linux
-        ;;
-    *)
-        echo "Error: Unknown OS type: $os_type"
-        exit 1
+    case "$(uname -s)" in
+        Darwin) OS_TYPE=darwin;;
+        Linux) OS_TYPE=linux;;
+        *) echo "Error: Unknown OS type"; exit 1;;
     esac
 }
 
 get_arch_type() {
-    arch_type="$(uname -m)"
-
-    case "$arch_type" in
-    arm64)
-        ARCH_TYPE=arm64
-        ;;
-    aarch64)
-        ARCH_TYPE=arm64
-        ;;
-    x86_64)
-        ARCH_TYPE=amd64
-        ;;
-    amd64)
-        ARCH_TYPE=amd64
-        ;;
-    *)
-        echo "Error: Unknown CPU type: $arch_type"
-        exit 1
+    case "$(uname -m)" in
+        arm64|aarch64) ARCH_TYPE=arm64;;
+        x86_64|amd64) ARCH_TYPE=amd64;;
+        *) echo "Error: Unknown CPU type"; exit 1;;
     esac
 }
 
+do_download() {
+  echo "Downloading '${BIN}' from '${DOWNLOAD_SOURCE}', OS: '${OS_TYPE}', Arch: '${ARCH_TYPE}', Version: '${VERSION}'"
+
+  case "${DOWNLOAD_SOURCE}" in
+      github) download_from_github;;
+      aws) download_from_aws;;
+      *) echo "ERROR: Unknown download source"; exit 1;;
+  esac
+}
+
+# Check required commands
+command -v wget >/dev/null 2>&1 || { echo "ERROR: wget command not found. Please install wget."; exit 1; }
+
+while getopts "s:v:o:r:i" opt; do
+    case "$opt" in
+        s) DOWNLOAD_SOURCE="$OPTARG";;
+        v) VERSION="$OPTARG";;
+        o) GITHUB_ORG="$OPTARG";;
+        r) GITHUB_REPO="$OPTARG";;
+        i) INSTALL_DIR="/usr/local/bin/";;
+        *) usage; exit 1;;
+    esac
+done
+
+# Main
 get_os_type
 get_arch_type
-
-if [ -n "${OS_TYPE}" ] && [ -n "${ARCH_TYPE}" ]; then
-    echo "Downloading ${BIN}, OS: ${OS_TYPE}, Arch: ${ARCH_TYPE}, Version: ${VERSION}"
-
-    if [ "${VERSION}" = "latest" ]; then
-        wget "https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest/download/${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz"
-    else
-        wget "https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${VERSION}/${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz"
-    fi
-
-    tar xvf ${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz && rm ${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz && echo "Run '${BIN} --help' to get started"
-fi
+do_download
+verify_sha256sum "$(PWD)"/${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz "$(PWD)"/${BIN}-${OS_TYPE}-${ARCH_TYPE}.sha256sum
+install_binary


### PR DESCRIPTION
## What's changed

1. Support to download from aws-cn bucket, for example:

   ```
   ./hack/install.sh -s aws
   ```

2. Support to verify sha256;

3. Support to install the `gtctl` to system path if set `-i` option;

4. Add manually triggered github action to release script to aws-cn S3 bucket;