### PR TITLE
feat: support bitnamic etcd chart and add charts cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ setup-e2e: ## Setup e2e test environment.
 
 .PHONY: e2e
 e2e: gtctl setup-e2e ## Run e2e.
-	go test -timeout 8m -v ./tests/e2e/... && kind delete clusters $(CLUSTER)
+	go test -timeout 20m -v ./tests/e2e/... && kind delete clusters $(CLUSTER)
 
 .PHONY: lint
 lint: golangci-lint gtctl ## Run lint.

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ setup-e2e: ## Setup e2e test environment.
 
 .PHONY: e2e
 e2e: gtctl setup-e2e ## Run e2e.
-	go test -timeout 20m -v ./tests/e2e/... && kind delete clusters $(CLUSTER)
+	go test -timeout 10m -v ./tests/e2e/... && kind delete clusters $(CLUSTER)
 
 .PHONY: lint
 lint: golangci-lint gtctl ## Run lint.

--- a/hack/e2e/setup-e2e-env.sh
+++ b/hack/e2e/setup-e2e-env.sh
@@ -21,6 +21,7 @@ set -o pipefail
 CLUSTER=e2e-cluster
 REGISTRY_NAME=kind-registry
 REGISTRY_PORT=5001
+KIND_NODE_IMAGE=kindest/node:v1.24.15
 
 function check_prerequisites() {
     if ! hash docker 2>/dev/null; then
@@ -59,7 +60,7 @@ function create_kind_cluster() {
     done
 
     # create a cluster with the local registry enabled in containerd
-    cat <<EOF | kind create cluster --name "${CLUSTER}" --config=-
+    cat <<EOF | kind create cluster --image ${KIND_NODE_IMAGE} --name "${CLUSTER}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:

--- a/pkg/cmd/gtctl/cluster/create/create.go
+++ b/pkg/cmd/gtctl/cluster/create/create.go
@@ -51,7 +51,7 @@ type ClusterCliOptions struct {
 	EtcdChartVersion               string
 	EtcdStorageClassName           string
 	EtcdStorageSize                string
-	EtcdDataDir                    string
+	EtcdClusterSize                string
 
 	// The options for deploying GreptimeDBCluster in bare-metal.
 	BareMetal          bool
@@ -96,7 +96,7 @@ func NewCreateClusterCommand(l logger.Logger) *cobra.Command {
 	cmd.Flags().StringVar(&options.EtcdNamespace, "etcd-namespace", "default", "The namespace of etcd cluster.")
 	cmd.Flags().StringVar(&options.EtcdStorageClassName, "etcd-storage-class-name", "standard", "The etcd storage class name.")
 	cmd.Flags().StringVar(&options.EtcdStorageSize, "etcd-storage-size", "10Gi", "the etcd persistent volume size.")
-	cmd.Flags().StringVar(&options.EtcdDataDir, "etcd-data-dir", "/var/lib/etcd", "the etcd data directory.")
+	cmd.Flags().StringVar(&options.EtcdClusterSize, "etcd-cluster-size", "1", "the etcd cluster size.")
 	cmd.Flags().BoolVar(&options.BareMetal, "bare-metal", false, "Deploy the greptimedb cluster on bare-metal environment.")
 	cmd.Flags().StringVar(&options.GreptimeBinVersion, "greptime-bin-version", "", "The version of greptime binary(can be override by config file).")
 	cmd.Flags().StringVar(&options.Config, "config", "", "Configuration to deploy the greptimedb cluster on bare-metal environment.")
@@ -261,7 +261,7 @@ func deployEtcdCluster(ctx context.Context, l logger.Logger, options *ClusterCli
 		EtcdChartVersion:     options.EtcdChartVersion,
 		EtcdStorageClassName: options.EtcdStorageClassName,
 		EtcdStorageSize:      options.EtcdStorageSize,
-		EtcdDataDir:          options.EtcdDataDir,
+		EtcdClusterSize:      options.EtcdClusterSize,
 		ConfigValues:         options.Set.etcdConfig,
 	}
 

--- a/pkg/deployer/k8s/constants.go
+++ b/pkg/deployer/k8s/constants.go
@@ -16,9 +16,11 @@ package k8s
 
 const (
 	GreptimeDBChartName         = "greptimedb"
-	GreptimeDBEtcdChartName     = "greptimedb-etcd"
 	GreptimeDBOperatorChartName = "greptimedb-operator"
 
 	GreptimeChartIndexURL           = "https://raw.githubusercontent.com/GreptimeTeam/helm-charts/gh-pages/index.yaml"
 	GreptimeChartReleaseDownloadURL = "https://github.com/GreptimeTeam/helm-charts/releases/download"
+
+	EtcdBitnamiOCIRegistry  = "oci://registry-1.docker.io/bitnamicharts/etcd"
+	DefaultEtcdChartVersion = "9.2.0"
 )

--- a/pkg/deployer/k8s/deployer.go
+++ b/pkg/deployer/k8s/deployer.go
@@ -118,7 +118,7 @@ func (d *deployer) CreateGreptimeDBCluster(ctx context.Context, name string, opt
 		return err
 	}
 
-	manifests, err := d.helmManager.LoadAndRenderChart(ctx, resourceName, resourceNamespace, helm.GreptimeDBChartName, options.GreptimeDBChartVersion, options)
+	manifests, err := d.helmManager.LoadAndRenderChart(ctx, resourceName, resourceNamespace, helm.GreptimeDBChartName, options.GreptimeDBChartVersion, *options)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (d *deployer) CreateEtcdCluster(ctx context.Context, name string, options *
 	)
 	options.ConfigValues += disableRBACConfig
 
-	manifests, err := d.helmManager.LoadAndRenderChart(ctx, resourceName, resourceNamespace, helm.EtcdBitnamiOCIRegistry, helm.DefaultEtcdChartVersion, options)
+	manifests, err := d.helmManager.LoadAndRenderChart(ctx, resourceName, resourceNamespace, helm.EtcdBitnamiOCIRegistry, helm.DefaultEtcdChartVersion, *options)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func (d *deployer) CreateGreptimeDBOperator(ctx context.Context, name string, op
 		return err
 	}
 
-	manifests, err := d.helmManager.LoadAndRenderChart(ctx, resourceName, resourceNamespace, helm.GreptimeDBOperatorChartName, options.GreptimeDBOperatorChartVersion, options)
+	manifests, err := d.helmManager.LoadAndRenderChart(ctx, resourceName, resourceNamespace, helm.GreptimeDBOperatorChartName, options.GreptimeDBOperatorChartVersion, *options)
 	if err != nil {
 		return err
 	}

--- a/pkg/deployer/k8s/deployer.go
+++ b/pkg/deployer/k8s/deployer.go
@@ -29,11 +29,11 @@ import (
 )
 
 type deployer struct {
-	render  *helm.Render
-	client  *kube.Client
-	timeout time.Duration
-	logger  logger.Logger
-	dryRun  bool
+	helmManager *helm.Manager
+	client      *kube.Client
+	timeout     time.Duration
+	logger      logger.Logger
+	dryRun      bool
 }
 
 var _ Interface = &deployer{}
@@ -41,14 +41,14 @@ var _ Interface = &deployer{}
 type Option func(*deployer)
 
 func NewDeployer(l logger.Logger, opts ...Option) (Interface, error) {
-	r, err := helm.NewRender()
+	hm, err := helm.NewManager(l)
 	if err != nil {
 		return nil, err
 	}
 
 	d := &deployer{
-		render: r,
-		logger: l,
+		helmManager: hm,
+		logger:      l,
 	}
 
 	for _, opt := range opts {
@@ -118,27 +118,10 @@ func (d *deployer) CreateGreptimeDBCluster(ctx context.Context, name string, opt
 		return err
 	}
 
-	values, err := d.render.GenerateHelmValues(*options)
+	manifests, err := d.helmManager.LoadAndRenderChart(ctx, resourceName, resourceNamespace, helm.GreptimeDBChartName, options.GreptimeDBChartVersion, options)
 	if err != nil {
 		return err
 	}
-	d.logger.V(3).Infof("create greptimedb cluster with values: %v", values)
-
-	downloadURL, err := d.getChartDownloadURL(ctx, GreptimeDBChartName, options.GreptimeDBChartVersion)
-	if err != nil {
-		return err
-	}
-
-	chart, err := d.render.LoadChartFromRemoteCharts(ctx, downloadURL)
-	if err != nil {
-		return err
-	}
-
-	manifests, err := d.render.GenerateManifests(ctx, resourceName, resourceNamespace, chart, values)
-	if err != nil {
-		return err
-	}
-	d.logger.V(3).Infof("create greptimedb cluster with manifests: %s", string(manifests))
 
 	if d.dryRun {
 		d.logger.V(0).Info(string(manifests))
@@ -190,22 +173,10 @@ func (d *deployer) CreateEtcdCluster(ctx context.Context, name string, options *
 	)
 	options.ConfigValues += disableRBACConfig
 
-	values, err := d.render.GenerateHelmValues(*options)
+	manifests, err := d.helmManager.LoadAndRenderChart(ctx, resourceName, resourceNamespace, helm.EtcdBitnamiOCIRegistry, helm.DefaultEtcdChartVersion, options)
 	if err != nil {
 		return err
 	}
-	d.logger.V(3).Infof("create etcd cluster with values: %v", values)
-
-	chart, err := d.render.Pull(ctx, EtcdBitnamiOCIRegistry, DefaultEtcdChartVersion)
-	if err != nil {
-		return err
-	}
-
-	manifests, err := d.render.GenerateManifests(ctx, resourceName, resourceNamespace, chart, values)
-	if err != nil {
-		return err
-	}
-	d.logger.V(3).Infof("create etcd cluster with manifests: %s", string(manifests))
 
 	if d.dryRun {
 		d.logger.V(0).Info(string(manifests))
@@ -234,27 +205,10 @@ func (d *deployer) CreateGreptimeDBOperator(ctx context.Context, name string, op
 		return err
 	}
 
-	values, err := d.render.GenerateHelmValues(*options)
+	manifests, err := d.helmManager.LoadAndRenderChart(ctx, resourceName, resourceNamespace, helm.GreptimeDBOperatorChartName, options.GreptimeDBOperatorChartVersion, options)
 	if err != nil {
 		return err
 	}
-	d.logger.V(3).Infof("create greptimedb-operator with values: %v", values)
-
-	downloadURL, err := d.getChartDownloadURL(ctx, GreptimeDBOperatorChartName, options.GreptimeDBOperatorChartVersion)
-	if err != nil {
-		return err
-	}
-
-	chart, err := d.render.LoadChartFromRemoteCharts(ctx, downloadURL)
-	if err != nil {
-		return err
-	}
-
-	manifests, err := d.render.GenerateManifests(ctx, GreptimeDBOperatorChartName, resourceNamespace, chart, values)
-	if err != nil {
-		return err
-	}
-	d.logger.V(3).Infof("create greptimedb-operator with manifests: %s", string(manifests))
 
 	if d.dryRun {
 		d.logger.V(0).Info(string(manifests))
@@ -279,30 +233,4 @@ func (d *deployer) splitNamescapedName(name string) (string, string, error) {
 	}
 
 	return split[0], split[1], nil
-}
-
-func (d *deployer) getChartDownloadURL(ctx context.Context, chartName, version string) (string, error) {
-	indexFile, err := d.render.GetIndexFile(ctx, GreptimeChartIndexURL)
-	if err != nil {
-		return "", err
-	}
-
-	var downloadURL string
-	if version == "" {
-		chartVersion, err := d.render.GetLatestChart(indexFile, chartName)
-		if err != nil {
-			return "", err
-		}
-		downloadURL = chartVersion.URLs[0]
-		d.logger.V(3).Infof("get latest chart '%s', version '%s', url: '%s'",
-			chartName, chartVersion.Version, downloadURL)
-	} else {
-		// The download URL example: 'https://github.com/GreptimeTeam/helm-charts/releases/download/greptimedb-0.1.1-alpha.3/greptimedb-0.1.1-alpha.3.tgz'.
-		chartName := chartName + "-" + version
-		downloadURL = fmt.Sprintf("%s/%s/%s.tgz", GreptimeChartReleaseDownloadURL, chartName, chartName)
-		d.logger.V(3).Infof("get given version chart '%s', version '%s', url: '%s'",
-			chartName, version, downloadURL)
-	}
-
-	return downloadURL, nil
 }

--- a/pkg/deployer/types.go
+++ b/pkg/deployer/types.go
@@ -91,10 +91,11 @@ type DeleteGreptimeDBClusterOption struct{}
 type CreateEtcdClusterOptions struct {
 	EtcdChartVersion string
 
+	// The parameters reference: https://artifacthub.io/packages/helm/bitnami/etcd.
+	EtcdClusterSize      string `helm:"replicaCount"`
 	ImageRegistry        string `helm:"image.registry"`
-	EtcdStorageClassName string `helm:"storage.storageClassName"`
-	EtcdStorageSize      string `helm:"storage.volumeSize"`
-	EtcdDataDir          string `helm:"storage.dataDir"`
+	EtcdStorageClassName string `helm:"persistence.storageClass"`
+	EtcdStorageSize      string `helm:"persistence.size"`
 	ConfigValues         string `helm:"*"`
 }
 

--- a/pkg/helm/constants.go
+++ b/pkg/helm/constants.go
@@ -10,17 +10,17 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.
-
-package k8s
+// limitations under the License.r
+package helm
 
 const (
-	GreptimeDBChartName         = "greptimedb"
-	GreptimeDBOperatorChartName = "greptimedb-operator"
+	DefaultChartsCache = ".gtctl/charts-cache"
 
 	GreptimeChartIndexURL           = "https://raw.githubusercontent.com/GreptimeTeam/helm-charts/gh-pages/index.yaml"
 	GreptimeChartReleaseDownloadURL = "https://github.com/GreptimeTeam/helm-charts/releases/download"
 
-	EtcdBitnamiOCIRegistry  = "oci://registry-1.docker.io/bitnamicharts/etcd"
-	DefaultEtcdChartVersion = "9.2.0"
+	GreptimeDBChartName         = "greptimedb"
+	GreptimeDBOperatorChartName = "greptimedb-operator"
+	EtcdBitnamiOCIRegistry      = "oci://registry-1.docker.io/bitnamicharts/etcd"
+	DefaultEtcdChartVersion     = "9.2.0"
 )

--- a/pkg/helm/constants.go
+++ b/pkg/helm/constants.go
@@ -10,7 +10,8 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.r
+// limitations under the License.
+
 package helm
 
 const (

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -37,6 +37,7 @@ import (
 	"helm.sh/helm/v3/pkg/strvals"
 	"sigs.k8s.io/yaml"
 
+	"github.com/GreptimeTeam/gtctl/pkg/logger"
 	fileutils "github.com/GreptimeTeam/gtctl/pkg/utils/file"
 )
 
@@ -44,42 +45,85 @@ const (
 	helmFieldTag = "helm"
 )
 
-const (
-	defaultChartsCache = ".gtctl/charts-cache"
-)
-
-type TemplateRender interface {
-	GenerateManifests(ctx context.Context, releaseName, namespace string, chart *chart.Chart, values map[string]interface{}) ([]byte, error)
-}
-
-type Render struct {
+// Manager is the Helm charts manager. The implementation is based on Helm SDK.
+// The main purpose of Manager is:
+// 1. Load the chart from remote charts and save them in cache directory.
+// 2. Generate the manifests from the chart with the values.
+type Manager struct {
 	// indexFile is the index file of the remote charts.
 	indexFile *IndexFile
 
 	// chartCache is the cache directory for the charts.
 	chartsCacheDir string
+
+	// logger is the logger for the Manager.
+	logger logger.Logger
 }
 
-var _ TemplateRender = &Render{}
+type Option func(*Manager)
 
-func NewRender() (*Render, error) {
-	homeDir, err := os.UserHomeDir()
+func NewManager(l logger.Logger, opts ...Option) (*Manager, error) {
+	r := &Manager{logger: l}
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	if r.chartsCacheDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		r.chartsCacheDir = filepath.Join(homeDir, DefaultChartsCache)
+	}
+
+	if err := fileutils.CreateDirIfNotExists(r.chartsCacheDir); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func WithChartsCacheDir(chartsCacheDir string) func(*Manager) {
+	return func(r *Manager) {
+		r.chartsCacheDir = chartsCacheDir
+	}
+}
+
+// LoadAndRenderChart loads the chart from the remote charts and render the manifests with the values.
+func (r *Manager) LoadAndRenderChart(ctx context.Context, name, namespace, chartName, chartVersion string, options interface{}) ([]byte, error) {
+	values, err := r.generateHelmValues(options)
 	if err != nil {
 		return nil, err
 	}
+	r.logger.V(3).Infof("create '%s' with values: %v", name, values)
 
-	chartsCacheDir := filepath.Join(homeDir, defaultChartsCache)
-
-	if err := fileutils.CreateDirIfNotExists(chartsCacheDir); err != nil {
-		return nil, err
+	var helmChart *chart.Chart
+	if isOCIChar(chartName) {
+		helmChart, err = r.pullFromOCIRegistry(chartName, chartVersion)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		downloadURL, err := r.getChartDownloadURL(ctx, chartName, chartVersion)
+		if err != nil {
+			return nil, err
+		}
+		helmChart, err = r.loadChartFromRemoteCharts(ctx, downloadURL)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return &Render{
-		chartsCacheDir: chartsCacheDir,
-	}, nil
+	manifests, err := r.generateManifests(ctx, name, namespace, helmChart, values)
+	if err != nil {
+		return nil, err
+	}
+	r.logger.V(3).Infof("create '%s' with manifests: %s", name, string(manifests))
+
+	return manifests, nil
 }
 
-func (r *Render) LoadChartFromRemoteCharts(ctx context.Context, downloadURL string) (*chart.Chart, error) {
+func (r *Manager) loadChartFromRemoteCharts(ctx context.Context, downloadURL string) (*chart.Chart, error) {
 	parsedURL, err := url.Parse(downloadURL)
 	if err != nil {
 		return nil, err
@@ -121,11 +165,7 @@ func (r *Render) LoadChartFromRemoteCharts(ctx context.Context, downloadURL stri
 	return loader.LoadArchive(bytes.NewReader(body))
 }
 
-func (r *Render) LoadChartFromLocalDirectory(directory string) (*chart.Chart, error) {
-	return loader.LoadDir(directory)
-}
-
-func (r *Render) GenerateManifests(ctx context.Context, releaseName, namespace string,
+func (r *Manager) generateManifests(ctx context.Context, releaseName, namespace string,
 	chart *chart.Chart, values map[string]interface{}) ([]byte, error) {
 	client, err := r.newHelmClient(releaseName, namespace)
 	if err != nil {
@@ -146,7 +186,7 @@ func (r *Render) GenerateManifests(ctx context.Context, releaseName, namespace s
 	return manifests.Bytes(), nil
 }
 
-func (r *Render) GenerateHelmValues(input interface{}) (map[string]interface{}, error) {
+func (r *Manager) generateHelmValues(input interface{}) (map[string]interface{}, error) {
 	var rawArgs []string
 	valueOf := reflect.ValueOf(input)
 
@@ -178,7 +218,7 @@ func (r *Render) GenerateHelmValues(input interface{}) (map[string]interface{}, 
 	return nil, nil
 }
 
-func (r *Render) GetLatestChart(indexFile *IndexFile, chartName string) (*ChartVersion, error) {
+func (r *Manager) getLatestChart(indexFile *IndexFile, chartName string) (*ChartVersion, error) {
 	if versions, ok := indexFile.Entries[chartName]; ok {
 		if versions.Len() > 0 {
 			// The Entries are already sorted by version so the position 0 always point to the latest version.
@@ -194,7 +234,7 @@ func (r *Render) GetLatestChart(indexFile *IndexFile, chartName string) (*ChartV
 	return nil, fmt.Errorf("chart %s not found", chartName)
 }
 
-func (r *Render) GetIndexFile(ctx context.Context, indexURL string) (*IndexFile, error) {
+func (r *Manager) getIndexFile(ctx context.Context, indexURL string) (*IndexFile, error) {
 	if r.indexFile != nil {
 		return r.indexFile, nil
 	}
@@ -226,9 +266,9 @@ func (r *Render) GetIndexFile(ctx context.Context, indexURL string) (*IndexFile,
 	return indexFile, nil
 }
 
-// Pull pulls the chart from the remote OCI registry, for example, oci://registry-1.docker.io/bitnamicharts/etcd.
-func (r *Render) Pull(_ context.Context, OCIRegistry, version string) (*chart.Chart, error) {
-	packageName := r.packageName(path.Base(OCIRegistry), version)
+// pullFromOCIRegistry pulls the chart from the remote OCI registry, for example, oci://registry-1.docker.io/bitnamicharts/etcd.
+func (r *Manager) pullFromOCIRegistry(chartsRegistry, version string) (*chart.Chart, error) {
+	packageName := r.packageName(path.Base(chartsRegistry), version)
 	if !r.isInChartsCache(packageName) {
 		registryClient, err := registry.NewClient(
 			registry.ClientOptDebug(false),
@@ -248,8 +288,9 @@ func (r *Render) Pull(_ context.Context, OCIRegistry, version string) (*chart.Ch
 		client.Version = version
 		client.DestDir = r.chartsCacheDir
 
+		r.logger.V(3).Infof("pulling chart '%s', version: '%s' from OCI registry", chartsRegistry, version)
 		// Execute the pull action
-		if _, err := client.Run(OCIRegistry); err != nil {
+		if _, err := client.Run(chartsRegistry); err != nil {
 			return nil, err
 		}
 	}
@@ -262,12 +303,15 @@ func (r *Render) Pull(_ context.Context, OCIRegistry, version string) (*chart.Ch
 	return loader.LoadArchive(bytes.NewReader(data))
 }
 
-func (r *Render) isInChartsCache(packageName string) bool {
+func (r *Manager) isInChartsCache(packageName string) bool {
 	res, _ := fileutils.IsFileExists(filepath.Join(r.chartsCacheDir, packageName))
+	if res {
+		r.logger.V(3).Infof("chart '%s' is already in cache", packageName)
+	}
 	return res
 }
 
-func (r *Render) newHelmClient(releaseName, namespace string) (*action.Install, error) {
+func (r *Manager) newHelmClient(releaseName, namespace string) (*action.Install, error) {
 	helmClient := action.NewInstall(new(action.Configuration))
 	helmClient.DryRun = true
 	helmClient.ReleaseName = releaseName
@@ -279,8 +323,38 @@ func (r *Render) newHelmClient(releaseName, namespace string) (*action.Install, 
 	return helmClient, nil
 }
 
-func (r *Render) packageName(chartName, version string) string {
+func (r *Manager) getChartDownloadURL(ctx context.Context, chartName, version string) (string, error) {
+	indexFile, err := r.getIndexFile(ctx, GreptimeChartIndexURL)
+	if err != nil {
+		return "", err
+	}
+
+	var downloadURL string
+	if version == "" {
+		chartVersion, err := r.getLatestChart(indexFile, chartName)
+		if err != nil {
+			return "", err
+		}
+		downloadURL = chartVersion.URLs[0]
+		r.logger.V(3).Infof("get latest chart '%s', version '%s', url: '%s'",
+			chartName, chartVersion.Version, downloadURL)
+	} else {
+		// The download URL example: 'https://github.com/GreptimeTeam/helm-charts/releases/download/greptimedb-0.1.1-alpha.3/greptimedb-0.1.1-alpha.3.tgz'.
+		chartName := chartName + "-" + version
+		downloadURL = fmt.Sprintf("%s/%s/%s.tgz", GreptimeChartReleaseDownloadURL, chartName, chartName)
+		r.logger.V(3).Infof("get given version chart '%s', version '%s', url: '%s'",
+			chartName, version, downloadURL)
+	}
+
+	return downloadURL, nil
+}
+
+func (r *Manager) packageName(chartName, version string) string {
 	return fmt.Sprintf("%s-%s.tgz", chartName, version)
+}
+
+func isOCIChar(url string) bool {
+	return strings.HasPrefix(url, "oci://")
 }
 
 // loadIndex is from 'helm/pkg/index.go'.

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -173,7 +173,7 @@ func TestRender_GenerateEtcdHelmValues(t *testing.T) {
 		ImageRegistry:        "registry.cn-hangzhou.aliyuncs.com",
 		EtcdStorageClassName: "ebs-sc",
 		EtcdStorageSize:      "11Gi",
-		EtcdDataDir:          "/var/etcd",
+		EtcdClusterSize:      "3",
 		ConfigValues:         "image.tag=latest",
 	}
 
@@ -185,9 +185,9 @@ func TestRender_GenerateEtcdHelmValues(t *testing.T) {
 
 	ArgsStr := []string{
 		"image.registry=registry.cn-hangzhou.aliyuncs.com",
-		"storage.storageClassName=ebs-sc",
-		"storage.volumeSize=11Gi",
-		"storage.dataDir=/var/etcd",
+		"persistence.storageClass=ebs-sc",
+		"persistence.size=11Gi",
+		"replicaCount=3",
 		"image.tag=latest",
 	}
 


### PR DESCRIPTION
## What's changed

1. Support bitnami etcd chart that stores in OCI registry;
2. Support helm charts cache;
3. Refactor helm `Render` and rename to `Manager`, and simplify the interface(the user only need to call one API `LoadAndRenderChart()`);

## Related issues

- https://github.com/GreptimeTeam/gtctl/issues/133
- https://github.com/GreptimeTeam/gtctl/issues/88
