### PR TITLE
fix: create new context for bare-metal deployer

### DIFF
--- a/pkg/cmd/gtctl/cluster/create/create.go
+++ b/pkg/cmd/gtctl/cluster/create/create.go
@@ -128,7 +128,7 @@ func NewCluster(args []string, options ClusterCliOptions, l logger.Logger) error
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(options.Timeout)*time.Second)
 		defer cancel()
 	}
-	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	clusterDeployer, err := newDeployer(l, clusterName, &options)

--- a/pkg/deployer/baremetal/deployer.go
+++ b/pkg/deployer/baremetal/deployer.go
@@ -42,7 +42,6 @@ type Deployer struct {
 	wg     sync.WaitGroup
 	bm     *component.BareMetalCluster
 	ctx    context.Context
-	stop   context.CancelFunc
 
 	createNoDirs      bool
 	workingDirs       component.WorkingDirs
@@ -58,13 +57,12 @@ var _ Interface = &Deployer{}
 type Option func(*Deployer)
 
 func NewDeployer(l logger.Logger, clusterName string, opts ...Option) (Interface, error) {
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	d := &Deployer{
 		logger: l,
 		config: config.DefaultConfig(),
 		ctx:    ctx,
-		stop:   stop,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
for bare-metal mode, deployment and operation are using the same `ctx`, causing the running binaries to shutdown if we pass the value to `--timeout`.

so the fix here is: separate the `ctx` of deployment and operation, do not let `--timeout` disturb the running binaries.