### PR TITLE
fix: etcd install fail

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -47,8 +47,8 @@ const (
 )
 
 var (
-	// KubernetesVersion is the target version of the kubernetes.
-	KubernetesVersion string
+	// KubeVersion is the target version of the kubernetes.
+	KubeVersion string
 )
 
 // Manager is the Helm charts manager. The implementation is based on Helm SDK.
@@ -324,7 +324,7 @@ func (r *Manager) isInChartsCache(packageName string) bool {
 }
 
 func (r *Manager) newHelmClient(releaseName, namespace string) (*action.Install, error) {
-	kubeVersion, err := chartutil.ParseKubeVersion(KubernetesVersion)
+	kubeVersion, err := chartutil.ParseKubeVersion(KubeVersion)
 	if err != nil {
 		return nil, fmt.Errorf("invalid kube version '%s': %s", kubeVersion, err)
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	// KubeVersion is the default target version of the kubernetes.
+	// KubeVersion is the target version of the kubernetes.
 	KubeVersion string = "v1.20.0"
 )
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	// KubeVersion is the target version of the kubernetes.
+	// KubeVersion is the default target version of the kubernetes.
 	KubeVersion string = "v1.20.0"
 )
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -48,7 +48,7 @@ const (
 
 var (
 	// KubeVersion is the target version of the kubernetes.
-	KubeVersion string
+	KubeVersion string = "v1.20.0"
 )
 
 // Manager is the Helm charts manager. The implementation is based on Helm SDK.

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 
 	greptimev1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
+
 	"github.com/GreptimeTeam/gtctl/pkg/helm"
 )
 

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 
 	greptimev1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
+	"github.com/GreptimeTeam/gtctl/pkg/helm"
 )
 
 type Client struct {
@@ -102,6 +103,12 @@ func NewClient(kubeconfig string) (*Client, error) {
 			panic(err)
 		}
 	})
+
+	kubeVersion, err := kubeClient.ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubernetes server version: %v\n", err)
+	}
+	helm.KubernetesVersion = kubeVersion.String()
 
 	return &Client{
 		kubeClient:        kubeClient,

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -108,7 +108,7 @@ func NewClient(kubeconfig string) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kubernetes server version: %v\n", err)
 	}
-	helm.KubernetesVersion = kubeVersion.String()
+	helm.KubeVersion = kubeVersion.String()
 
 	return &Client{
 		kubeClient:        kubeClient,


### PR DESCRIPTION
gtctl version: v0.1.0-beta.3
kind kubernetes version: 1.27.3

When running gtctl locally, The following error message appears:
```
./gtctl cluster create mycluster

Creating GreptimeDB cluster 'mycluster' in namespace 'default' ...
  ✓ Installing greptimedb-operator successfully 🎉
  ✗ Installing etcd cluster failed 😵‍💫
Error: error while applying helm chart: the server could not find the requested resource
error while applying helm chart: the server could not find the requested resource
```

Run `./gtctl cluster create mycluster -v=5` and observe the [PodDisruptionBudget](https://github.com/bitnami/charts/blob/main/bitnami/etcd/templates/pdb.yaml#L7) yaml file the resource apiVersion is policy/v1beta1, but the policy/v1beta1 API version of PodDisruptionBudget is no longer served as of k8s v1.25. We should use the policy/v1 version of apiVersion.

By getting the kubernetes version, inject to helm client, can run gtctl successfully:
```
./bin/gtctl cluster create mycluster
Creating GreptimeDB cluster 'mycluster' in namespace 'default' ...
  ✓ Installing greptimedb-operator successfully 🎉
  ✓ Installing etcd cluster successfully 🎉
  ✓ Installing GreptimeDB cluster successfully 🎉

Now you can use the following commands to access the GreptimeDB cluster:

MySQL >
$ kubectl port-forward svc/mycluster-frontend -n default 4002:4002 > connections-mysql.out &
$ mysql -h 127.0.0.1 -P 4002

PostgreSQL>
$ kubectl port-forward svc/mycluster-frontend -n default 4003:4003 > connections-pg.out &
$ psql -h 127.0.0.1 -p 4003

Thank you for using GreptimeDB! Check for more information on https://greptime.com. 😊

Invest in Data, Harvest over Time. 🔑
```