### PR TITLE
fix: psql connect error

### DIFF
--- a/pkg/cmd/gtctl/cluster/create/create.go
+++ b/pkg/cmd/gtctl/cluster/create/create.go
@@ -340,7 +340,7 @@ func printTips(l logger.Logger, clusterName string, options *ClusterCliOptions) 
 	if !options.BareMetal {
 		l.V(0).Infof("%s", fmt.Sprintf("%s kubectl port-forward svc/%s-frontend -n %s 4003:4003 > connections-pg.out &", logger.Bold("$"), clusterName, options.Namespace))
 	}
-	l.V(0).Infof("%s", fmt.Sprintf("%s psql -h 127.0.0.1 -p 4003", logger.Bold("$")))
+	l.V(0).Infof("%s", fmt.Sprintf("%s psql -h 127.0.0.1 -p 4003 -d public", logger.Bold("$")))
 	l.V(0).Infof("\nThank you for using %s! Check for more information on %s. 😊", logger.Bold("GreptimeDB"), logger.Bold("https://greptime.com"))
 	l.V(0).Infof("\n%s 🔑", logger.Bold("Invest in Data, Harvest over Time."))
 }


### PR DESCRIPTION
gtctl version:
```
GitCommit: 61684d90d7ceb873f51fb50d3b8a0bc1471da69d
GitVersion: 
GoVersion: go1.19
Compiler: gc
Platform: darwin/arm64
BuildDate: 2023-10-09T09:52:58Z
```

psql connect:
```
psql -h 127.0.0.1 -p 4003
psql: error: connection to server at "127.0.0.1", port 4003 failed: FATAL:  Database not found: greptime
```
link: https://docs.greptime.com/getting-started/try-out-greptimedb#connect .    need to add `-d public`