### PR TITLE
feat: support kubectl-style plugin

### DIFF
--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -1,0 +1,104 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// DefaultPluginPrefix is the default prefix for the plugin binary name.
+	DefaultPluginPrefix = "gtctl-"
+
+	// PluginSearchPathsEnvKey is the environment variable key for the plugin search paths.
+	PluginSearchPathsEnvKey = "GTCTL_PLUGIN_PATHS"
+)
+
+// Manager manages and executes the plugins.
+type Manager struct {
+	prefix      string
+	searchPaths []string
+}
+
+func NewManager() (*Manager, error) {
+	// Always search the current working directory.
+	pwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	m := &Manager{
+		prefix:      DefaultPluginPrefix,
+		searchPaths: []string{pwd},
+	}
+
+	pluginSearchPaths := os.Getenv(PluginSearchPathsEnvKey)
+	if len(pluginSearchPaths) > 0 {
+		m.searchPaths = append(strings.Split(pluginSearchPaths, ":"), m.searchPaths...)
+	}
+
+	return m, nil
+}
+
+// ShouldRun returns true whether you should run the plugin.
+func (m *Manager) ShouldRun(err error) bool {
+	// The error is returned by cobra itself.
+	return strings.Contains(err.Error(), "unknown command")
+}
+
+// Run searches for the plugin and runs it.
+func (m *Manager) Run(args []string) error {
+	if len(args) < 1 {
+		return nil // No arguments provided, normal help message will be shown.
+	}
+
+	pluginPath, err := m.searchPlugins(args[0])
+	if err != nil {
+		return err
+	}
+
+	pluginCmd := exec.Command(pluginPath, args[1:]...)
+	pluginCmd.Stdin = os.Stdin
+	pluginCmd.Stdout = os.Stdout
+	pluginCmd.Stderr = os.Stderr
+	if err := pluginCmd.Run(); err != nil {
+		return fmt.Errorf("failed to run plugin '%s': %v", pluginPath, err)
+	}
+
+	return nil
+}
+
+func (m *Manager) searchPlugins(name string) (string, error) {
+	if len(m.searchPaths) == 0 {
+		return "", fmt.Errorf("no plugin search paths provided")
+	}
+
+	// Construct plugin binary name gtctl-<subcmd>.
+	pluginName := m.prefix + name
+	for _, path := range m.searchPaths {
+		pluginPath := filepath.Join(path, pluginName)
+		if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
+			continue
+		}
+
+		return pluginPath, nil
+	}
+
+	return "", fmt.Errorf("error: unknown command %q for \"gtctl\"", name)
+}

--- a/pkg/plugins/manager_test.go
+++ b/pkg/plugins/manager_test.go
@@ -1,0 +1,36 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPluginManager(t *testing.T) {
+	t.Setenv(PluginSearchPathsEnvKey, "./testdata")
+	pm, err := NewManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pluginName := "foo-plugin"
+	receiveErr := fmt.Errorf("unknown command: %s", pluginName)
+	if pm.ShouldRun(receiveErr) {
+		if err := pm.Run([]string{pluginName, "1", "2", "3"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/pkg/plugins/testdata/gtctl-foo-plugin
+++ b/pkg/plugins/testdata/gtctl-foo-plugin
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Just prints the args it receives.
+echo "Hello from gtctl-foo-plugin.sh, args: $*"


### PR DESCRIPTION
## What's the feature

We can use the [kubectl-sytle](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/) plugin now. For example, if we put the custom plugin in the `/usr/local/bin`, like `gtctl-foo`, we can use it like this:

```
GTCTL_PLUGIN_PATHS=/usr/local/bin gtctl foo 1 2 3
```

The `gtctl` will search the plugin from the `GTCTL_PLUGIN_PATHS`(separate by `:`) and run it.

Related issue: https://github.com/GreptimeTeam/gtctl/issues/24.