### PR TITLE
fix: change local artifact validation logic from tag to `if` blocks

### DIFF
--- a/cmd/gtctl/cluster_create.go
+++ b/cmd/gtctl/cluster_create.go
@@ -213,7 +213,6 @@ func NewCluster(args []string, options *clusterCreateCliOptions, l logger.Logger
 	}
 
 	if err = cluster.Create(ctx, createOptions); err != nil {
-		l.Error(err.Error())
 		return err
 	}
 

--- a/cmd/gtctl/cluster_create.go
+++ b/cmd/gtctl/cluster_create.go
@@ -213,6 +213,7 @@ func NewCluster(args []string, options *clusterCreateCliOptions, l logger.Logger
 	}
 
 	if err = cluster.Create(ctx, createOptions); err != nil {
+		l.Error(err.Error())
 		return err
 	}
 

--- a/cmd/gtctl/main.go
+++ b/cmd/gtctl/main.go
@@ -42,12 +42,11 @@ func NewRootCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:           "gtctl",
-		Short:         "gtctl is a command-line tool for managing GreptimeDB cluster.",
-		Long:          fmt.Sprintf("%s\ngtctl is a command-line tool for managing GreptimeDB cluster.", GtctlTextBanner),
-		Version:       version.Get().String(),
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:          "gtctl",
+		Short:        "gtctl is a command-line tool for managing GreptimeDB cluster.",
+		Long:         fmt.Sprintf("%s\ngtctl is a command-line tool for managing GreptimeDB cluster.", GtctlTextBanner),
+		Version:      version.Get().String(),
+		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			type verboser interface {
 				SetVerbosity(log.Level)

--- a/cmd/gtctl/main.go
+++ b/cmd/gtctl/main.go
@@ -76,13 +76,16 @@ func main() {
 		panic(err)
 	}
 
-	if err := NewRootCommand().Execute(); err != nil {
-		if pm.ShouldRun(err) {
-			if err := pm.Run(os.Args[1:]); err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
-			os.Exit(0)
+	if pm.ShouldRun(os.Args[1]) {
+		if err = pm.Run(os.Args[1:]); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
 		}
+		os.Exit(0)
+	}
+
+	if err = NewRootCommand().Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 }

--- a/pkg/cluster/baremetal/create.go
+++ b/pkg/cluster/baremetal/create.go
@@ -73,6 +73,11 @@ func (c *Cluster) createCluster(ctx context.Context, options *opt.CreateOptions)
 	if c.config.Cluster.Artifact != nil {
 		if c.config.Cluster.Artifact.Local != "" {
 			binPath = c.config.Cluster.Artifact.Local
+
+			// Ensure the binary path exists.
+			if exist, _ := fileutils.IsFileExists(binPath); !exist {
+				return fmt.Errorf("greptimedb cluster artifact '%s' is not exist", binPath)
+			}
 		} else {
 			src, err := c.am.NewSource(artifacts.GreptimeBinName, c.config.Cluster.Artifact.Version,
 				artifacts.ArtifactTypeBinary, clusterOpt.UseGreptimeCNArtifacts)
@@ -124,6 +129,11 @@ func (c *Cluster) createEtcdCluster(ctx context.Context, options *opt.CreateOpti
 	if c.config.Etcd.Artifact != nil {
 		if c.config.Etcd.Artifact.Local != "" {
 			binPath = c.config.Etcd.Artifact.Local
+
+			// Ensure the binary path exists.
+			if exist, _ := fileutils.IsFileExists(binPath); !exist {
+				return fmt.Errorf("etcd artifact '%s' is not exist", binPath)
+			}
 		} else {
 			src, err := c.am.NewSource(artifacts.EtcdBinName, c.config.Etcd.Artifact.Version,
 				artifacts.ArtifactTypeBinary, etcdOpt.UseGreptimeCNArtifacts)

--- a/pkg/config/baremetal.go
+++ b/pkg/config/baremetal.go
@@ -48,7 +48,7 @@ type BareMetalClusterComponentsConfig struct {
 
 type Artifact struct {
 	// Local is the local path of binary(greptime or etcd).
-	Local string `yaml:"local" validate:"omitempty,file"`
+	Local string `yaml:"local" validate:"omitempty,filepath"`
 
 	// Version is the release version of binary(greptime or etcd).
 	// Usually, it points to the version of binary of GitHub release.

--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -20,6 +20,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	fileutils "github.com/GreptimeTeam/gtctl/pkg/utils/file"
 )
 
 const (
@@ -66,9 +68,9 @@ func NewManager() (*Manager, error) {
 }
 
 // ShouldRun returns true whether you should run the plugin.
-func (m *Manager) ShouldRun(err error) bool {
-	// The error is returned by cobra itself.
-	return strings.Contains(err.Error(), "unknown command")
+func (m *Manager) ShouldRun(name string) bool {
+	_, err := m.searchPlugins(name)
+	return err == nil
 }
 
 // Run searches for the plugin and runs it.
@@ -102,7 +104,7 @@ func (m *Manager) searchPlugins(name string) (string, error) {
 	pluginName := m.prefix + name
 	for _, path := range m.searchPaths {
 		pluginPath := filepath.Join(path, pluginName)
-		if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
+		if exist, _ := fileutils.IsFileExists(pluginPath); !exist {
 			continue
 		}
 

--- a/pkg/plugins/manager_test.go
+++ b/pkg/plugins/manager_test.go
@@ -15,7 +15,6 @@
 package plugins
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -27,8 +26,7 @@ func TestPluginManager(t *testing.T) {
 	}
 
 	pluginName := "foo-plugin"
-	receiveErr := fmt.Errorf("unknown command: %s", pluginName)
-	if pm.ShouldRun(receiveErr) {
+	if pm.ShouldRun(pluginName) {
 		if err := pm.Run([]string{pluginName, "1", "2", "3"}); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
- disable the SilenceErrors option, so the error from each cmd can surface
- change artifact local field`file` tag to `filepath`, only validate the file path, not existence
- check file existence in codebase, and surface more readable error