### PR TITLE
fix: avoid pushing invalid addr args

### DIFF
--- a/pkg/components/frontend.go
+++ b/pkg/components/frontend.go
@@ -19,10 +19,8 @@ package components
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"path"
-	"strconv"
 	"sync"
 
 	greptimedbclusterv1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
@@ -103,11 +101,11 @@ func (f *frontend) BuildArgs(params ...interface{}) []string {
 		fmt.Sprintf("--metasrv-addr=%s", f.metaSrvAddr),
 	}
 
-	args = generateAddrArg("--http-addr", f.config.HTTPAddr, nodeId, args)
-	args = generateAddrArg("--rpc-addr", f.config.GRPCAddr, nodeId, args)
-	args = generateAddrArg("--mysql-addr", f.config.MysqlAddr, nodeId, args)
-	args = generateAddrArg("--postgres-addr", f.config.PostgresAddr, nodeId, args)
-	args = generateAddrArg("--opentsdb-addr", f.config.OpentsdbAddr, nodeId, args)
+	args = GenerateAddrArg("--http-addr", f.config.HTTPAddr, nodeId, args)
+	args = GenerateAddrArg("--rpc-addr", f.config.GRPCAddr, nodeId, args)
+	args = GenerateAddrArg("--mysql-addr", f.config.MysqlAddr, nodeId, args)
+	args = GenerateAddrArg("--postgres-addr", f.config.PostgresAddr, nodeId, args)
+	args = GenerateAddrArg("--opentsdb-addr", f.config.OpentsdbAddr, nodeId, args)
 
 	if len(f.config.Config) > 0 {
 		args = append(args, fmt.Sprintf("-c=%s", f.config.Config))
@@ -120,7 +118,7 @@ func (f *frontend) BuildArgs(params ...interface{}) []string {
 
 func (f *frontend) IsRunning(_ context.Context) bool {
 	for i := 0; i < f.config.Replicas; i++ {
-		addr := formatAddrArg(f.config.HTTPAddr, i)
+		addr := FormatAddrArg(f.config.HTTPAddr, i)
 		healthy := fmt.Sprintf("http://%s/health", addr)
 
 		resp, err := http.Get(healthy)
@@ -140,31 +138,4 @@ func (f *frontend) IsRunning(_ context.Context) bool {
 		}
 	}
 	return true
-}
-
-// formatAddrArg formats the given addr and nodeId to a valid socket string.
-// This function will return an empty string when the given addr is empty.
-func formatAddrArg(addr string, nodeId int) string {
-	// return empty result if the address is not specified
-	if len(addr) == 0 {
-		return addr
-	}
-
-	// The "addr" is validated when set.
-	host, port, _ := net.SplitHostPort(addr)
-	portInt, _ := strconv.Atoi(port)
-
-	return net.JoinHostPort(host, strconv.Itoa(portInt+nodeId))
-}
-
-// generateAddrArg pushes arg into args array, return the new args array.
-func generateAddrArg(config string, addr string, nodeId int, args []string) []string {
-	socketAddr := formatAddrArg(addr, nodeId)
-
-	// don't generate param if the socket address is empty
-	if len(socketAddr) == 0 {
-		return args
-	}
-
-	return append(args, fmt.Sprintf("%s=%s", config, socketAddr))
 }

--- a/pkg/components/metasrv.go
+++ b/pkg/components/metasrv.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/http"
 	"path"
-	"strconv"
 	"sync"
 	"time"
 
@@ -123,9 +122,9 @@ func (m *metaSrv) BuildArgs(params ...interface{}) []string {
 		m.Name(), "start",
 		fmt.Sprintf("--store-addr=%s", m.config.StoreAddr),
 		fmt.Sprintf("--server-addr=%s", m.config.ServerAddr),
-		fmt.Sprintf("--http-addr=%s", generateMetaSrvAddr(m.config.HTTPAddr, nodeID)),
-		fmt.Sprintf("--bind-addr=%s", generateMetaSrvAddr(bindAddr, nodeID)),
 	}
+	args = GenerateAddrArg("--http-addr", m.config.HTTPAddr, nodeID, args)
+	args = GenerateAddrArg("--bind-addr", bindAddr, nodeID, args)
 
 	if len(m.config.Config) > 0 {
 		args = append(args, fmt.Sprintf("-c=%s", m.config.Config))
@@ -136,7 +135,7 @@ func (m *metaSrv) BuildArgs(params ...interface{}) []string {
 
 func (m *metaSrv) IsRunning(_ context.Context) bool {
 	for i := 0; i < m.config.Replicas; i++ {
-		addr := generateMetaSrvAddr(m.config.HTTPAddr, i)
+		addr := FormatAddrArg(m.config.HTTPAddr, i)
 		_, httpPort, err := net.SplitHostPort(addr)
 		if err != nil {
 			m.logger.V(5).Infof("failed to split host port in %s: %s", m.Name(), err)
@@ -159,10 +158,4 @@ func (m *metaSrv) IsRunning(_ context.Context) bool {
 	}
 
 	return true
-}
-
-func generateMetaSrvAddr(addr string, nodeID int) string {
-	host, port, _ := net.SplitHostPort(addr)
-	portInt, _ := strconv.Atoi(port)
-	return net.JoinHostPort(host, strconv.Itoa(portInt+nodeID))
 }

--- a/pkg/components/utils.go
+++ b/pkg/components/utils.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package components
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// FormatAddrArg formats the given addr and nodeId to a valid socket string.
+// This function will return an empty string when the given addr is empty.
+func FormatAddrArg(addr string, nodeId int) string {
+	// return empty result if the address is not specified
+	if len(addr) == 0 {
+		return addr
+	}
+
+	// The "addr" is validated when set.
+	host, port, _ := net.SplitHostPort(addr)
+	portInt, _ := strconv.Atoi(port)
+
+	return net.JoinHostPort(host, strconv.Itoa(portInt+nodeId))
+}
+
+// GenerateAddrArg pushes arg into args array, return the new args array.
+func GenerateAddrArg(config string, addr string, nodeId int, args []string) []string {
+	socketAddr := FormatAddrArg(addr, nodeId)
+
+	// don't generate param if the socket address is empty
+	if len(socketAddr) == 0 {
+		return args
+	}
+
+	return append(args, fmt.Sprintf("%s=%s", config, socketAddr))
+}


### PR DESCRIPTION
closes #194

The generated command now becomes 
```
 run 'frontend.0' binary '../target/greptimedb-dev/release/greptime' with args: '[--log-level=info frontend start --metasrv-addr=127.0.0.1:3002 -c=../config/frontend.example.toml]', log: '~/.gtctl/mycluster/logs/frontend.0'
```

without invalid args