### PR TITLE
chore: remove opentsdb addr

### DIFF
--- a/pkg/components/frontend.go
+++ b/pkg/components/frontend.go
@@ -105,7 +105,6 @@ func (f *frontend) BuildArgs(params ...interface{}) []string {
 	args = GenerateAddrArg("--rpc-addr", f.config.GRPCAddr, nodeId, args)
 	args = GenerateAddrArg("--mysql-addr", f.config.MysqlAddr, nodeId, args)
 	args = GenerateAddrArg("--postgres-addr", f.config.PostgresAddr, nodeId, args)
-	args = GenerateAddrArg("--opentsdb-addr", f.config.OpentsdbAddr, nodeId, args)
 
 	if len(f.config.Config) > 0 {
 		args = append(args, fmt.Sprintf("-c=%s", f.config.Config))

--- a/pkg/config/baremetal.go
+++ b/pkg/config/baremetal.go
@@ -76,7 +76,6 @@ type Frontend struct {
 	PostgresAddr string `yaml:"postgresAddr" validate:"omitempty,hostname_port"`
 	MetaAddr     string `yaml:"metaAddr" validate:"omitempty,hostname_port"`
 	MysqlAddr    string `yaml:"mysqlAddr" validate:"omitempty,hostname_port"`
-	OpentsdbAddr string `yaml:"opentsdbAddr" validate:"omitempty,hostname_port"`
 
 	Replicas     int    `yaml:"replicas" validate:"gt=0"`
 	Config       string `yaml:"config" validate:"omitempty,filepath"`
@@ -111,7 +110,6 @@ func DefaultBareMetalConfig() *BareMetalClusterConfig {
 				GRPCAddr:     "0.0.0.0:4001",
 				MysqlAddr:    "0.0.0.0:4002",
 				PostgresAddr: "0.0.0.0:4003",
-				OpentsdbAddr: "0.0.0.0:4242",
 			},
 			MetaSrv: &MetaSrv{
 				Replicas:   1,

--- a/pkg/helm/loader_test.go
+++ b/pkg/helm/loader_test.go
@@ -43,7 +43,7 @@ func TestLoadAndRenderChart(t *testing.T) {
 		ReleaseName:  "gtctl-ut",
 		Namespace:    "default",
 		ChartName:    artifacts.GreptimeDBClusterChartName,
-		ChartVersion: "0.1.2",
+		ChartVersion: "0.1.29",
 		FromCNRegion: false,
 		ValuesOptions: opt.CreateClusterOptions{
 			ImageRegistry:               "registry.cn-hangzhou.aliyuncs.com",

--- a/pkg/helm/testdata/db-manifests.yaml
+++ b/pkg/helm/testdata/db-manifests.yaml
@@ -13,7 +13,7 @@ spec:
         limits: {}
         requests: {}
   frontend:
-    replicas: 1
+    replicas: 3
     template:
       main:
         resources:

--- a/pkg/helm/testdata/db-manifests.yaml
+++ b/pkg/helm/testdata/db-manifests.yaml
@@ -33,7 +33,6 @@ spec:
   grpcServicePort: 4001
   mysqlServicePort: 4002
   postgresServicePort: 4003
-  openTSDBServicePort: 4242
   initializer:
     image: 'registry.cn-hangzhou.aliyuncs.com/greptime/greptimedb-initializer:0.1.0-alpha.17'
   storage:

--- a/pkg/helm/testdata/db-manifests.yaml
+++ b/pkg/helm/testdata/db-manifests.yaml
@@ -8,32 +8,50 @@ metadata:
 spec:
   base:
     main:
-      image: 'registry.cn-hangzhou.aliyuncs.com/greptime/greptimedb:v0.4.1'
+      image: 'registry.cn-hangzhou.aliyuncs.com/greptime/greptimedb:v0.8.0'
       resources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 500m
-          memory: 512Mi
+        limits: {}
+        requests: {}
   frontend:
-    replicas: 3
+    replicas: 1
+    template:
+      main:
+        resources:
+          requests: 
+            {}
+          limits: 
+            {}
   meta:
     replicas: 3
     etcdEndpoints:
       - mycluster-etcd.default:2379
+    template:
+      main:
+        resources:
+          requests: 
+            {}
+          limits: 
+            {}
   datanode:
     replicas: 3
+    template:
+      main:
+        resources:
+          requests: 
+            {}
+          limits: 
+            {}
     storage:
       storageClassName: ebs-sc
       storageSize: 11Gi
       storageRetainPolicy: Delete
-      walDir: /tmp/greptimedb/wal
+      dataHome: /data/greptimedb
+      walDir: /data/greptimedb/wal
   httpServicePort: 4000
   grpcServicePort: 4001
   mysqlServicePort: 4002
   postgresServicePort: 4003
   initializer:
-    image: 'registry.cn-hangzhou.aliyuncs.com/greptime/greptimedb-initializer:0.1.0-alpha.17'
-  storage:
+    image: 'registry.cn-hangzhou.aliyuncs.com/greptime/greptimedb-initializer:0.1.0-alpha.25'
+  objectStorage:
     {}

--- a/tests/e2e/greptimedbcluster_test.go
+++ b/tests/e2e/greptimedbcluster_test.go
@@ -41,7 +41,7 @@ const (
                      )
                      PARTITION ON COLUMNS (n) (
                         n < 5,
-                        n < 9,
+                        n >= 5 AND n < 9,
                         n >= 9
 					)`
 


### PR DESCRIPTION
In the new version, OpentsdbAddr is not used.
So,I delete the OpentsdbAddr  in order to run gtctl correctly