### PR TITLE
feat: dashboard use ip instead of localhost

### DIFF
--- a/pkg/cluster/baremetal/cluster.go
+++ b/pkg/cluster/baremetal/cluster.go
@@ -50,7 +50,7 @@ type Cluster struct {
 type ClusterComponents struct {
 	MetaSrv  components.ClusterComponent
 	Datanode components.ClusterComponent
-	Frontend components.ClusterComponent
+	Frontend components.Frontend
 	Etcd     components.ClusterComponent
 }
 

--- a/pkg/cluster/baremetal/create.go
+++ b/pkg/cluster/baremetal/create.go
@@ -236,7 +236,7 @@ func (c *Cluster) Wait(ctx context.Context, close bool) error {
 	csd := c.mm.GetClusterScopeDirs()
 	if !close {
 		c.logger.V(0).Infof("The cluster(pid=%d, version=%s) is running in bare-metal mode now...", os.Getpid(), v)
-		c.logger.V(0).Infof("To view dashboard by accessing: %s", logger.Bold("http://localhost:4000/dashboard/"))
+		c.cc.Frontend.PrintDashboardLog()
 	} else {
 		c.logger.Warnf("The cluster(pid=%d, version=%s) run in bare-metal has been shutting down...", os.Getpid(), v)
 		c.logger.Warnf("To view the failure by browsing logs in: %s", logger.Bold(csd.LogsDir))

--- a/pkg/components/frontend.go
+++ b/pkg/components/frontend.go
@@ -168,5 +168,5 @@ func (f *Frontend) PrintDashboardLog() {
 		log = fmt.Sprintf(format, host, port)
 	}
 
-	f.logger.V(0).Infof("If enable dashboard, view it by accessing: %s", logger.Bold(log))
+	f.logger.V(0).Infof("If enabled dashboard, view it by accessing: %s", logger.Bold(log))
 }

--- a/pkg/components/utils.go
+++ b/pkg/components/utils.go
@@ -19,6 +19,7 @@ package components
 import (
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 )
 
@@ -47,4 +48,21 @@ func GenerateAddrArg(config string, addr string, nodeId int, args []string) []st
 	}
 
 	return append(args, fmt.Sprintf("%s=%s", config, socketAddr))
+}
+
+func HostnameIP() (ip string, err error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+
+	ips, err := net.LookupHost(hostname)
+	if err != nil {
+		return "", err
+	}
+
+	if len(ips) == 0 {
+		return "", nil
+	}
+	return ips[0], nil
 }


### PR DESCRIPTION
- issue: https://github.com/GreptimeTeam/gtctl/issues/211
- summary: dashboard link log use ip instead of localhost


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced logging functionality with a new method for accessing the dashboard.
	- Introduced a new utility function to dynamically retrieve the machine's IP address.

- **Improvements**
	- Increased visibility of the Frontend struct, making it accessible from other packages.
	- Improved API usability by aligning method signatures with the new exported struct definition.

- **Refactor**
	- Adjusted the type of the Frontend component for more specialized functionality within the cluster architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->